### PR TITLE
Fixed NPE when using the default PrismKernel Constructor.

### DIFF
--- a/src/main/java/prism/framework/DependencyInjector.java
+++ b/src/main/java/prism/framework/DependencyInjector.java
@@ -25,7 +25,10 @@ final class DependencyInjector
     protected DependencyInjector(GraphContext graphContext)
     {
         this.graphContext = graphContext;
-        this.graphContext.getApplicationGraph().injectStatics();
+
+        if (null != this.graphContext) {
+            this.graphContext.getApplicationGraph().injectStatics();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixed #4 
