### PR TITLE
Add Activity & Application modules to provide global services.

### DIFF
--- a/src/main/java/prism/module/ActivityModule.java
+++ b/src/main/java/prism/module/ActivityModule.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package prism.module;
+
+import android.app.Activity;
+import android.app.FragmentManager;
+import android.view.LayoutInflater;
+import android.view.MenuInflater;
+import android.view.WindowManager;
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Singleton;
+
+/**
+ * Provides access to Android's Activity-level services.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+@Module(library = true)
+@SuppressWarnings("unused")
+final public class ActivityModule
+{
+    /**
+     * Activity context to fetch services from.
+     */
+    final private Activity activity;
+
+    /**
+     * @param activity The Activity that all of the provided resources
+     *                 will be based off of.
+     */
+    public ActivityModule(Activity activity)
+    {
+        this.activity = activity;
+    }
+
+    /**
+     * Current Activity instance.
+     *
+     * Avoid depending on this service in favor of more granular services.
+     *
+     * @return The currently activity instance that this module is bound to.
+     */
+    @Provides
+    @Singleton
+    public Activity activityContext()
+    {
+        return this.activity;
+    }
+
+    /**
+     * Instantiates a layout XML file into its corresponding View objects.
+     *
+     * @return LayoutInflater instance that this Window retrieved from its Context.
+     */
+    @Provides
+    @Singleton
+    public LayoutInflater inflater()
+    {
+        return this.activity.getLayoutInflater();
+    }
+
+    /**
+     * Interface for interacting with Fragment objects inside of an Activity.
+     *
+     * @return The FragmentManager for interacting with fragments associated with this activity.
+     */
+    @Provides
+    @Singleton
+    public FragmentManager fragmentManager()
+    {
+        return this.activity.getFragmentManager();
+    }
+
+    /**
+     * Used to instantiate menu XML files into Menu objects.
+     *
+     * @return a MenuInflater with the current activity context.
+     */
+    @Provides
+    @Singleton
+    public MenuInflater menuInflater()
+    {
+        return this.activity.getMenuInflater();
+    }
+
+    /**
+     * The interface that apps use to talk to the window manager.
+     *
+     * @return The window manager for showing custom windows.
+     */
+    @Provides
+    @Singleton
+    public WindowManager windowManager()
+    {
+        return this.activity.getWindowManager();
+    }
+}

--- a/src/main/java/prism/module/ApplicationModule.java
+++ b/src/main/java/prism/module/ApplicationModule.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2015 Ink Applications, LLC.
+ * Distributed under the MIT License (http://opensource.org/licenses/MIT)
+ */
+package prism.module;
+
+import android.app.Application;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.content.res.Resources;
+import dagger.Module;
+import dagger.Provides;
+
+import javax.inject.Singleton;
+
+/**
+ * Provides access to Android's Application-level services.
+ *
+ * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
+ */
+@Module(library = true)
+@SuppressWarnings("unused")
+final public class ApplicationModule
+{
+    /**
+     * Application context to fetch services from.
+     */
+    final private Application application;
+
+    /**
+     * @param application The Application that all of the provided resources
+     *                    will be based off of.
+     */
+    public ApplicationModule(Application application)
+    {
+        this.application = application;
+    }
+
+    /**
+     * Android Application instance.
+     *
+     * Avoid depending on this service in favor of more granular services.
+     *
+     * @return The root Android application instance that is bound to the module.
+     */
+    @Provides
+    @Singleton
+    public Application application()
+    {
+        return this.application;
+    }
+
+    /**
+     * Generic system context.
+     *
+     * Avoid depending on this service in favor of more granular services.
+     *
+     * @return The context of the single, global Application object of the current process.
+     */
+    @Provides
+    @Singleton
+    public Context applicationContext()
+    {
+        return this.application.getApplicationContext();
+    }
+
+    /**
+     * Information you can retrieve about a particular application.
+     *
+     * @return The full application info for this context's package.
+     */
+    @Provides
+    @Singleton
+    public ApplicationInfo applicationInfo()
+    {
+        return this.application.getApplicationInfo();
+    }
+
+    /**
+     * Provides access to an application's raw asset files.
+     *
+     * @return An AssetManager instance for your application's package.
+     */
+    @Provides
+    @Singleton
+    public AssetManager assets()
+    {
+       return this.application.getAssets();
+    }
+
+    /**
+     * This class provides applications access to the content model.
+     *
+     * @return A ContentResolver instance for your application's package.
+     */
+    @Provides
+    @Singleton
+    public ContentResolver contentResolver()
+    {
+        return this.application.getContentResolver();
+    }
+
+    /**
+     * Loads classes and resources from a repository.
+     *
+     * @return A class loader you can use to retrieve classes in this package.
+     */
+    @Provides
+    @Singleton
+    public ClassLoader classLoader()
+    {
+        return this.application.getClassLoader();
+    }
+
+    /**
+     * Retrieves various kinds of information related to the application
+     * packages that are currently installed on the device.
+     *
+     * @return A PackageManager instance to find global package information.
+     */
+    @Provides
+    @Singleton
+    public PackageManager packageManager()
+    {
+        return this.application.getPackageManager();
+    }
+
+    /**
+     * Keeps track of all non-code assets associated with an application.
+     *
+     * @return A Resources instance for your application's package.
+     */
+    @Provides
+    @Singleton
+    public Resources resources()
+    {
+        return this.application.getResources();
+    }
+
+    /**
+     * Application Shared Preferences.
+     *
+     * This provides a private-mode level shared preferences instance, since
+     * all other modes are deprecated.
+     * The provided instance does not allow concurrent writing.
+     * The instance is created under the name "Application". If you need to
+     * change this, you may create your own qualified provider.
+     *
+     * @return A SharedPreferences through which you can retrieve and modify its values.
+     */
+    @Provides
+    @Singleton
+    public SharedPreferences sharedPreferences()
+    {
+        return this.application.getSharedPreferences("Application", Context.MODE_PRIVATE);
+    }
+}


### PR DESCRIPTION
The application and activity context objects are god objects. This
provides default modules that break those context objects into
each of their provided services so that other services can stop relying
on them.