### PR TITLE
Add injection flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log
 ==========
 
+v1.1.0
+------
+
+ - Added an `@Injected` annotation in order to allow the injectors
+   to discriminate services that they should automatically inject.
+   This change was made in order to prevent dagger injections from running on
+   every class such as activities from third party libraries.
+ - A new constructor is available for the kernel that allows users to enforce
+   that the new injected annotation is present for injections to run.
+ - Module scoping functionality has been moved into the new injector annotation
+   and the old one has been deprecated. The new annotation will always take
+   precedence over the deprecated definitions, but will continue to work.
+
 v1.0.0
 ------
  - Created a base framework for injecting classes

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'android-maven'
 apply plugin: 'optional-base'
 
 group 'com.github.InkApplications'
-version 'v1.0.0'
+version 'v1.1.0'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -172,7 +172,7 @@ that same class.
 ```
 
 Doing so will allow you to give access to the modules only when the injected
-class is annotated with `@ModuleScope(ExampleModule.class)`
+class is annotated with `@Injected(moduleScope=ExampleModule.class)`
 
 ### Finishing Dagger Injection ###
 

--- a/src/main/java/prism/framework/DependencyInjector.java
+++ b/src/main/java/prism/framework/DependencyInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Ink Applications, LLC.
+ * Copyright (c) 2014-2015 Ink Applications, LLC.
  * Distributed under the MIT License (http://opensource.org/licenses/MIT)
  */
 package prism.framework;
@@ -21,10 +21,12 @@ final class DependencyInjector
      */
     final private GraphContext graphContext;
 
-    /** Constructor with an application graph. */
-    protected DependencyInjector(GraphContext graphContext)
+    final private boolean requireInjectionFlag;
+
+    protected DependencyInjector(GraphContext graphContext, boolean requireInjectionFlag)
     {
         this.graphContext = graphContext;
+        this.requireInjectionFlag = requireInjectionFlag;
 
         if (null != this.graphContext) {
             this.graphContext.getApplicationGraph().injectStatics();
@@ -84,6 +86,10 @@ final class DependencyInjector
      */
     public void inject(Object target)
     {
+        if (this.requireInjectionFlag && false == target.getClass().isAnnotationPresent(Injected.class)) {
+            return;
+        }
+
         ObjectGraph applicationGraph = this.graphContext.getApplicationGraph();
 
         applicationGraph.injectStatics();
@@ -102,21 +108,46 @@ final class DependencyInjector
      */
     public void inject(Object target, Activity context)
     {
+        if (this.requireInjectionFlag && false == target.getClass().isAnnotationPresent(Injected.class)) {
+            return;
+        }
+
         Object[] activityModules = this.graphContext.getActivityModules(context);
         ObjectGraph applicationGraph = this.graphContext.getApplicationGraph();
         ObjectGraph activityGraph = applicationGraph.plus(activityModules);
 
-        ModuleScope injectionScope = target.getClass().getAnnotation(ModuleScope.class);
+        Class injectionScope = this.getInjectionScope(target);
         if (null == injectionScope) {
             activityGraph.inject(target);
             return;
         }
 
         Map<Class, Object> scopeModules = this.graphContext.getScopeModules(context);
-        Object scopeModule = scopeModules.get(injectionScope.value());
+        Object scopeModule = scopeModules.get(injectionScope);
         ObjectGraph localGraph = activityGraph.plus(scopeModule);
 
         localGraph.injectStatics();
         localGraph.inject(target);
+    }
+
+    /**
+     * Find a scoped module that should be used for the target injectable.
+     *
+     * @param target The service that is being injected.
+     * @return The module specified by the injectable target.
+     */
+    private Class getInjectionScope(Object target)
+    {
+        Injected injectedScope = target.getClass().getAnnotation(Injected.class);
+        if (null != injectedScope) {
+            return  injectedScope.moduleScope();
+        }
+
+        ModuleScope moduleScope = target.getClass().getAnnotation(ModuleScope.class);
+        if (null != moduleScope) {
+            return moduleScope.value();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/prism/framework/Injected.java
+++ b/src/main/java/prism/framework/Injected.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Ink Applications, LLC.
+ * Copyright (c) 2015 Ink Applications, LLC.
  * Distributed under the MIT License (http://opensource.org/licenses/MIT)
  */
 package prism.framework;
@@ -10,20 +10,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines which module a target class should be a part of when running
- * module injections.
+ * Denotes that a service should be injected by the framework automatically.
  *
- * @deprecated as of 2.1 specify the module scope in the `@Injected` annotation
- *             instead of using this flag.
+ * This annotation does NOT cause the framework to inject any service, rather
+ * this is intended to prevent the framework from injecting services
+ * automatically unless this annotation is present.
+ *
+ * @since 1.1
  * @author Maxwell Vandervelde (Max@MaxVandervelde.com)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Deprecated
-public @interface ModuleScope
+public @interface Injected
 {
     /**
      * The Module class to include in the injection scope.
      */
-    Class value();
+    Class moduleScope();
 }

--- a/src/main/java/prism/framework/PrismKernel.java
+++ b/src/main/java/prism/framework/PrismKernel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Ink Applications, LLC.
+ * Copyright (c) 2014-2015 Ink Applications, LLC.
  * Distributed under the MIT License (http://opensource.org/licenses/MIT)
  */
 package prism.framework;
@@ -46,7 +46,20 @@ final public class PrismKernel
      */
     public PrismKernel(GraphContext graph)
     {
-        this.dependencyInjector = new DependencyInjector(graph);
+        this.dependencyInjector = new DependencyInjector(graph, false);
+        this.layoutInjector = new ActivityLayoutInjector();
+    }
+
+    /**
+     * Create an application with the specified object graphs.
+     *
+     * @param requireInjectionFlag Whether or not the dependency injector should
+     *     require the `@Injected` flag in order to inject an object
+     *     automatically.
+     */
+    public PrismKernel(GraphContext graph, boolean requireInjectionFlag)
+    {
+        this.dependencyInjector = new DependencyInjector(graph, requireInjectionFlag);
         this.layoutInjector = new ActivityLayoutInjector();
     }
 


### PR DESCRIPTION

Q             | A
--------------|-------
Bug fix?      | no
New feature?  | yes
BC breaks?    | no
Deprecations? | yes

----------------------------------------------------------------------

 - Added an `@Injected` annotation in order to allow the injectors
   to discriminate services that they should automatically inject.
   This change was made in order to prevent dagger injections from running on
   every class such as activities from third party libraries.
 - A new constructor is available for the kernel that allows users to enforce
   that the new injected annotation is present for injections to run.
 - Module scoping functionality has been moved into the new injector annotation
   and the old one has been deprecated. The new annotation will always take
   precedence over the deprecated definitions, but will continue to work.