### PR TITLE
Catch Dagger injection errors and log instead of crashing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+v1.1.0
+------
+ - Changed injections to not crash if the target is missing from any dagger
+   modules inject statements.
+ - Added an optional logger to the prism kernel that will be used for any
+   internal services. Currently used to log errors during injections due to
+   the change in preventing crashes.
+
 v1.0.0
 ------
  - Created a base framework for injecting classes

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,15 @@
+Prism Project Notices
+=====================
+
+Licenses
+--------
+
+This project contains sources from the following projects:
+
+### Apache Commons ###
+
+Sources from the Commons Logging library are used for the NoOpLogger included
+in this project. This code is licensed under Apache 2.0 (the copyright header
+is maintained in the file) and the only change made to the file is the package
+name.
+

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'android-maven'
 apply plugin: 'optional-base'
 
 group 'com.github.InkApplications'
-version 'v1.0.0'
+version 'v1.1.0'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 

--- a/src/main/java/prism/framework/NoOpLog.java
+++ b/src/main/java/prism/framework/NoOpLog.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package prism.framework;
+
+
+import java.io.Serializable;
+import org.apache.commons.logging.Log;
+
+
+/**
+ * <p>Trivial implementation of Log that throws away all messages.  No
+ * configurable system properties are supported.</p>
+ *
+ * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
+ * @author Rod Waldhoff
+ * @version $Id: NoOpLog.java 424107 2006-07-20 23:15:42Z skitching $
+ */
+class NoOpLog implements Log, Serializable {
+
+    /** Convenience constructor */
+    public NoOpLog() { }
+    /** Base constructor */
+    public NoOpLog(String name) { }
+    /** Do nothing */
+    public void trace(Object message) { }
+    /** Do nothing */
+    public void trace(Object message, Throwable t) { }
+    /** Do nothing */
+    public void debug(Object message) { }
+    /** Do nothing */
+    public void debug(Object message, Throwable t) { }
+    /** Do nothing */
+    public void info(Object message) { }
+    /** Do nothing */
+    public void info(Object message, Throwable t) { }
+    /** Do nothing */
+    public void warn(Object message) { }
+    /** Do nothing */
+    public void warn(Object message, Throwable t) { }
+    /** Do nothing */
+    public void error(Object message) { }
+    /** Do nothing */
+    public void error(Object message, Throwable t) { }
+    /** Do nothing */
+    public void fatal(Object message) { }
+    /** Do nothing */
+    public void fatal(Object message, Throwable t) { }
+
+    /**
+     * Debug is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isDebugEnabled() { return false; }
+
+    /**
+     * Error is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isErrorEnabled() { return false; }
+
+    /**
+     * Fatal is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isFatalEnabled() { return false; }
+
+    /**
+     * Info is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isInfoEnabled() { return false; }
+
+    /**
+     * Trace is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isTraceEnabled() { return false; }
+
+    /**
+     * Warn is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isWarnEnabled() { return false; }
+
+}

--- a/src/main/java/prism/framework/PrismKernel.java
+++ b/src/main/java/prism/framework/PrismKernel.java
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2014 Ink Applications, LLC.
+ * Copyright (c) 2014-2015 Ink Applications, LLC.
  * Distributed under the MIT License (http://opensource.org/licenses/MIT)
  */
 package prism.framework;
 
 import android.app.Activity;
+import org.apache.commons.logging.Log;
 
 /**
  * The core loader for the framework.
@@ -95,11 +96,26 @@ final public class PrismKernel
     }
 
     /**
-     * Changes Whether or not the framework will set thecontent view on
+     * Changes Whether or not the framework will set the content view on
      * activities during their bootstrap phase.
      */
     public void shouldInjectContentView(boolean runInjections)
     {
         this.injectContentView = runInjections;
+    }
+
+    /**
+     * Change the logger used for tracking injection problems.
+     *
+     * @param logger A logger to use for tracking injection problems or Null to
+     *               disable logging (default behavior.)
+     */
+    public void setLogger(Log logger)
+    {
+        if (null == logger) {
+            this.dependencyInjector.setLogger(new NoOpLog());
+        } else {
+            this.dependencyInjector.setLogger(logger);
+        }
     }
 }


### PR DESCRIPTION
In order to allow for automatic activity injections, we have
to allow dagger to run whether or not it is explicitly in
an `injects={}` section of a module.
Though, since this is a common oversight on projects, a
logger has been added with a big warning message when
this happens.

---

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | N/A |
